### PR TITLE
Use explicit .savegame directory name

### DIFF
--- a/doomgeneric/m_config.c
+++ b/doomgeneric/m_config.c
@@ -2115,7 +2115,7 @@ char *M_GetSaveGameDir(char *iwadname)
 
         free(topdir);
 #else
-        savegamedir = M_StringJoin(configdir, "/.savegame/", NULL);
+        savegamedir = M_StringJoin(configdir, DIR_SEPARATOR_S, ".savegame/", NULL);
 
         M_MakeDirectory(savegamedir);
 

--- a/doomgeneric/m_config.c
+++ b/doomgeneric/m_config.c
@@ -2115,7 +2115,7 @@ char *M_GetSaveGameDir(char *iwadname)
 
         free(topdir);
 #else
-        savegamedir = M_StringJoin(configdir, "savegame/", NULL);
+        savegamedir = M_StringJoin(configdir, "/.savegame/", NULL);
 
         M_MakeDirectory(savegamedir);
 


### PR DESCRIPTION
A small change which I hope makes sense.

`savegamedir` is constructed by concatenating `configdir` (`.`) with `"savegame/"`. This results in the creation of a directory called `.savegame`. While this was likely intended, the code is unintuitive.

This PR modifies the `savegamedir` path to be more explicit, by concatenating `configdir` + `DIR_SEPARATOR_S` + `".savegame/"`.