### PR TITLE
Added missing include guards for compiling without SDL/sound.

### DIFF
--- a/doomgeneric/i_sound.c
+++ b/doomgeneric/i_sound.c
@@ -65,7 +65,9 @@ int snd_sfxdevice = SNDDEVICE_SB;
 extern void I_InitTimidityConfig(void);
 extern sound_module_t sound_sdl_module;
 extern sound_module_t sound_pcsound_module;
+#ifdef FEATURE_SOUND
 extern music_module_t music_sdl_module;
+#endif /* FEATURE_SOUND */
 extern music_module_t music_opl_module;
 
 // For OPL module:
@@ -158,7 +160,9 @@ static void InitMusicModule(void)
 {
     int i;
 
+#ifdef FEATURE_SOUND
     music_module = &music_sdl_module; return;
+#endif /* FEATURE_SOUND */
 
     /*for (i=0; music_modules[i] != NULL; ++i)
     {

--- a/doomgeneric/i_swap.h
+++ b/doomgeneric/i_swap.h
@@ -20,6 +20,8 @@
 #ifndef __I_SWAP__
 #define __I_SWAP__
 
+#ifdef FEATURE_SOUND
+
 #include <SDL2/SDL_endian.h>
 
 // Endianess handling.
@@ -52,6 +54,15 @@
 #else
 #define doom_wtohs(x) (short int)(x)
 #endif
+
+#else
+	
+#define SHORT(x)  ((signed short) (x))
+#define LONG(x)   ((signed int) (x))
+
+#define SYS_LITTLE_ENDIAN
+
+#endif /* FEATURE_SOUND */
 
 #endif
 


### PR DESCRIPTION
Hello! Just noticed the default Makefile won't compile (the SDL one does), so hopefully this fixes it without messing up the SDL version. Works for me, at least!