### PR TITLE
Rotate n relocate

### DIFF
--- a/doomgeneric/doomgeneric.c
+++ b/doomgeneric/doomgeneric.c
@@ -4,7 +4,7 @@
 
 #include "doomgeneric.h"
 
-uint32_t* DG_ScreenBuffer = 0;
+uint32_t* DG_ScreenBuffer = NULL;
 
 void M_FindResponseFile(void);
 void D_DoomMain (void);
@@ -18,9 +18,12 @@ void doomgeneric_Create(int argc, char **argv)
 
 	M_FindResponseFile();
 
-	DG_ScreenBuffer = malloc(DOOMGENERIC_RESX * DOOMGENERIC_RESY * 4);
-
 	DG_Init();
+
+	if(NULL == DG_ScreenBuffer)
+	{
+	    DG_ScreenBuffer = malloc(DOOMGENERIC_RESX * DOOMGENERIC_RESY * 4);
+	}
 
 	D_DoomMain ();
 }

--- a/doomgeneric/i_video.c
+++ b/doomgeneric/i_video.c
@@ -48,7 +48,7 @@ rcsid[] = "$Id: i_x.c,v 1.6 1997/02/03 22:45:10 b1 Exp $";
 #include <sys/types.h>
 
 //#define CMAP256
-#// define ROTATE_SCREENBUFFER  // Needs testing at resolution > 320 * 200
+//#define ROTATE_SCREENBUFFER  // Needs testing at resolution > 320 * 200
 
 struct FB_BitField
 {


### PR DESCRIPTION
#  Relocating buffers into bss if desired.
Added simple changes which should prevent malloc if pointer is already assigned during DG_Init. This applies to both I_VideoBuffer and DG_ScreenBuffer.

# Added in code to rotate the buffer
Clockwise buffer rotation is disabled by default. Can be turned on by enabling the preprocessor in the i_video.c file or by adding in a compiler preprocessor flag `ROTATE_SCREENBUFFER`. 
By manipulating at cmap; you can bypass the need to create a third buffer and a copy operation which will degrade performance. The code is not tested at higher resolutions.