### PR TITLE
Add MinGW-w64 makefile

### DIFF
--- a/doomgeneric/Makefile.mingw
+++ b/doomgeneric/Makefile.mingw
@@ -1,0 +1,10 @@
+CC=x86_64-w64-mingw32-gcc
+LDFLAGS=-lgdi32
+
+doomgeneric: am_map.c doomdef.c doomgeneric.c doomgeneric_win.c doomstat.c dstrings.c dummy.c d_event.c d_items.c d_iwad.c d_loop.c d_main.c d_mode.c d_net.c f_finale.c f_wipe.c gusconf.c g_game.c hu_lib.c hu_stuff.c icon.c info.c i_cdmus.c i_endoom.c i_input.c i_joystick.c i_scale.c i_sound.c i_system.c i_timer.c i_video.c memio.c m_argv.c m_bbox.c m_cheat.c m_config.c m_controls.c m_fixed.c m_menu.c m_misc.c m_random.c p_ceilng.c p_doors.c p_enemy.c p_floor.c p_inter.c p_lights.c p_map.c p_maputl.c p_mobj.c p_plats.c p_pspr.c p_saveg.c p_setup.c p_sight.c p_spec.c p_switch.c p_telept.c p_tick.c p_user.c r_bsp.c r_data.c r_draw.c r_main.c r_plane.c r_segs.c r_sky.c r_things.c sha1.c sounds.c statdump.c st_lib.c st_stuff.c s_sound.c tables.c v_video.c wi_stuff.c w_checksum.c w_file.c w_file_stdc.c w_main.c w_wad.c z_zone.c
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+clean:
+	rm -f doomgeneric.exe
+
+.PHONY: clean


### PR DESCRIPTION
An alternative to Visual Studio might be nice!

This one worked for me.

```
% make -f Makefile.mingw
x86_64-w64-mingw32-gcc  am_map.c doomdef.c doomgeneric.c doomgeneric_win.c doomstat.c dstrings.c dummy.c d_event.c d_items.c d_iwad.c d_loop.c d_main.c d_mode.c d_net.c f_finale.c f_wipe.c gusconf.c g_game.c hu_lib.c hu_stuff.c icon.c info.c i_cdmus.c i_endoom.c i_input.c i_joystick.c i_scale.c i_sound.c i_system.c i_timer.c i_video.c memio.c m_argv.c m_bbox.c m_cheat.c m_config.c m_controls.c m_fixed.c m_menu.c m_misc.c m_random.c p_ceilng.c p_doors.c p_enemy.c p_floor.c p_inter.c p_lights.c p_map.c p_maputl.c p_mobj.c p_plats.c p_pspr.c p_saveg.c p_setup.c p_sight.c p_spec.c p_switch.c p_telept.c p_tick.c p_user.c r_bsp.c r_data.c r_draw.c r_main.c r_plane.c r_segs.c r_sky.c r_things.c sha1.c sounds.c statdump.c st_lib.c st_stuff.c s_sound.c tables.c v_video.c wi_stuff.c w_checksum.c w_file.c w_file_stdc.c w_main.c w_wad.c z_zone.c -o doomgeneric -lgdi32
p_maputl.c: In function 'InterceptsOverrun':
p_maputl.c:849:43: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  849 |     InterceptsMemoryOverrun(location + 8, (int) intercept->d.thing);
      |                                           ^

% wine ./doomgeneric.exe -iwad ../wad/doom1.wad
wine: could not open working directory L"unix\\Users\\sean\\src\\tmp\\doomgeneric\\doomgeneric\\", starting in the Windows directory.
                           Doom Generic 0.1
Z_Init: Init zone memory allocation daemon.
zone memory: 0000000001780040, 600000 allocated for zone
Using . for configuration and saves
V_Init: allocate screens.
M_LoadDefaults: Load system defaults.
saving config in .default.cfg
W_Init: Init WADfiles.
 adding ../wad/doom1.wad
Using .\.savegame/ for savegames
===========================================================================
                            DOOM Shareware
===========================================================================
 Doom Generic is free software, covered by the GNU General Public
 License.  There is NO warranty; not even for MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE. You are welcome to change and distribute
 copies under certain conditions. See the source for more information.
===========================================================================
I_Init: Setting up machine state.
M_Init: Init miscellaneous info.
R_Init: Init DOOM refresh daemon - ...................
P_Init: Init Playloop state.
S_Init: Setting up sound.
D_CheckNetGame: Checking network game status.
startskill 2  deathmatch: 0  startmap: 1  startepisode: 1
player 1 of 1 (1 nodes)
Emulating the behavior of the 'Doom 1.9' executable.
HU_Init: Setting up heads up display.
ST_Init: Init status bar.
I_InitGraphics: framebuffer: x_res: 640, y_res: 400, x_virtual: 640, y_virtual: 400, bpp: 32
I_InitGraphics: framebuffer: RGBA: 8888, red_off: 16, green_off: 8, blue_off: 0, transp_off: 24
I_InitGraphics: DOOM screen size: w x h: 320 x 200
I_InitGraphics: Auto-scaling factor: 2
```