### PR TITLE
Enable smaller MAXPLAYERS values

### DIFF
--- a/doomgeneric/doomdef.h
+++ b/doomgeneric/doomdef.h
@@ -42,7 +42,9 @@
 #define RANGECHECK
 
 // The maximum number of players, multiplayer/networking.
+#ifndef MAXPLAYERS
 #define MAXPLAYERS 4
+#endif
 
 // The current state of the game: whether we are
 // playing, gazing at the intermission screen,

--- a/doomgeneric/g_game.c
+++ b/doomgeneric/g_game.c
@@ -1709,11 +1709,13 @@ G_DeferedInitNew
 
 void G_DoNewGame (void) 
 {
+    int i;
     demoplayback = false; 
     netdemo = false;
     netgame = false;
     deathmatch = false;
-    playeringame[1] = playeringame[2] = playeringame[3] = 0;
+	for (i = 1; i < MAXPLAYERS; i++)
+		playeringame[i] = 0;
     respawnparm = false;
     fastparm = false;
     nomonsters = false;
@@ -2247,7 +2249,8 @@ void G_TimeDemo (char* name)
  
 boolean G_CheckDemoStatus (void) 
 { 
-    int             endtime; 
+    int             endtime;
+    int             i;
 	 
     if (timingdemo) 
     { 
@@ -2273,7 +2276,8 @@ boolean G_CheckDemoStatus (void)
 	netdemo = false;
 	netgame = false;
 	deathmatch = false;
-	playeringame[1] = playeringame[2] = playeringame[3] = 0;
+    for (i = 1; i < MAXPLAYERS; i++)
+        playeringame[i] = 0;
 	respawnparm = false;
 	fastparm = false;
 	nomonsters = false;

--- a/doomgeneric/p_enemy.c
+++ b/doomgeneric/p_enemy.c
@@ -495,9 +495,9 @@ P_LookForPlayers
     fixed_t	dist;
 
     c = 0;
-    stop = (actor->lastlook-1)&3;
+    stop = (actor->lastlook-1)%MAXPLAYERS;
 	
-    for ( ; ; actor->lastlook = (actor->lastlook+1)&3 )
+    for ( ; ; actor->lastlook = (actor->lastlook+1)%MAXPLAYERS)
     {
 	if (!playeringame[actor->lastlook])
 	    continue;

--- a/doomgeneric/p_mobj.c
+++ b/doomgeneric/p_mobj.c
@@ -767,6 +767,7 @@ void P_SpawnMapThing (mapthing_t* mthing)
     // check for players specially
     if (mthing->type <= 4)
     {
+    if (mthing->type > MAXPLAYERS) return;
 	// save spots for respawning in network games
 	playerstarts[mthing->type-1] = *mthing;
 	if (!deathmatch)


### PR DESCRIPTION
This fixes bugs when providing a MAXPLAYERS value smaller than 4.
The patch is mostly useful for embedded ports.

Using MSVC and Release build, with MAXPLAYERS=4 the bss size is:
0003:00013120 00041ac8H .bss                    DATA
And with MAXPLAYERS=1 it's:
0003:00013120 00040360H .bss                    DATA

Which equates to 5992 bytes saved. Not a lot but it still makes a difference