### PR TITLE
doomgeneric.h: Make interface compatible with C++

### DIFF
--- a/doomgeneric/doomgeneric.h
+++ b/doomgeneric/doomgeneric.h
@@ -26,6 +26,10 @@ typedef uint32_t pixel_t;
 
 extern pixel_t* DG_ScreenBuffer;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void doomgeneric_Create(int argc, char **argv);
 void doomgeneric_Tick();
 
@@ -37,5 +41,9 @@ void DG_SleepMs(uint32_t ms);
 uint32_t DG_GetTicksMs();
 int DG_GetKey(int* pressed, unsigned char* key);
 void DG_SetWindowTitle(const char * title);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //DOOM_GENERIC


### PR DESCRIPTION
When porting doomgeneric to our C++ based teaching operating system [hhuOS](https://github.com/hhuOS/hhuOS), I noticed that it is not possible to compile it as a C++ application. This is easily fixable by wrapping the interface functions in `doomgeneric.h` in an `extern "C" {}` block, when a C++ compiler is detected.