### PR TITLE
[FIX] support byteswapping no matter what

### DIFF
--- a/doomgeneric/i_swap.h
+++ b/doomgeneric/i_swap.h
@@ -20,9 +20,6 @@
 #ifndef __I_SWAP__
 #define __I_SWAP__
 
-#ifdef FEATURE_SOUND
-
-
 #ifdef __DJGPP__
 
 
@@ -35,34 +32,34 @@
 #else  // __DJGPP__
 
 
-#include <SDL_endian.h>
-
-// Endianess handling.
-// WAD files are stored little endian.
-
-// Just use SDL's endianness swapping functions.
-
-// These are deliberately cast to signed values; this is the behaviour
-// of the macros in the original source and some code relies on it.
-
-#define SHORT(x)  ((signed short) SDL_SwapLE16(x))
-#define LONG(x)   ((signed int) SDL_SwapLE32(x))
-
-// Defines for checking the endianness of the system.
-
-#if SDL_BYTEORDER == SYS_LIL_ENDIAN
+#if ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ )
 #define SYS_LITTLE_ENDIAN
-#elif SDL_BYTEORDER == SYS_BIG_ENDIAN
+#define SHORT(x)  ((signed short) (x))
+#define LONG(x)   ((signed int) (x))
+#elif ( __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ )
 #define SYS_BIG_ENDIAN
+
+static inline unsigned short swapLE16(unsigned short val) {
+	return ((val << 8) | (val >> 8));
+}
+
+static inline unsigned long swapLE32(unsigned long val) {
+	return ((val << 24) | ((val << 8) & 0x00FF0000) | ((val >> 8) & 0x0000FF00) | (val >> 24));
+}
+
+#define SHORT(x)  ((signed short) swapLE16(x))
+#define LONG(x)   ((signed int) swapLE32(x))
+#else
+#error "Unknown byte order"
 #endif
+
 
 // cosmito from lsdldoom
 #define doom_swap_s(x) \
         ((short int)((((unsigned short int)(x) & 0x00ff) << 8) | \
                               (((unsigned short int)(x) & 0xff00) >> 8))) 
 
-
-#if ( SDL_BYTEORDER == SDL_BIG_ENDIAN )
+#if ( __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ )
 #define doom_wtohs(x) doom_swap_s(x)
 #else
 #define doom_wtohs(x) (short int)(x)
@@ -71,15 +68,6 @@
 
 #endif  // __DJGPP__
 
-
-#else  // FEATURE_SOUND
-	
-#define SHORT(x)  ((signed short) (x))
-#define LONG(x)   ((signed int) (x))
-
-#define SYS_LITTLE_ENDIAN
-
-#endif /* FEATURE_SOUND */
 
 #endif
 


### PR DESCRIPTION
This allows byteswapping, no matter what features are enabled.  This is necessary for builds that don't use SDL to work properly on Big Endian platforms.  Rather than relying on SDL's implementation (and just not doing any swapping if sound is disabled???), this adds a minimal inline implementation for Big Endian, and equates to a no-op (as the original did) on Little Endian.