### PR TITLE
Revert "Only draw a new frame w/ a tic"

### DIFF
--- a/doomgeneric/d_loop.c
+++ b/doomgeneric/d_loop.c
@@ -703,7 +703,7 @@ static void SinglePlayerClear(ticcmd_set_t *set)
 // TryRunTics
 //
 
-int TryRunTics (void)
+void TryRunTics (void)
 {
     int	i;
     int	lowtic;
@@ -712,13 +712,11 @@ int TryRunTics (void)
     int realtics;
     int	availabletics;
     int	counts;
-    int ticsRan;
 
     // get real tics
     entertic = I_GetTime() / ticdup;
     realtics = entertic - oldentertics;
     oldentertics = entertic;
-    ticsRan = 0;
 
     // in singletics mode, run a single tic every time this function
     // is called.
@@ -780,7 +778,7 @@ int TryRunTics (void)
 
 	if (I_GetTime() / ticdup - entertic > 0)
 	{
-	    return ticsRan;
+	    return;
 	}
 
         I_Sleep(1);
@@ -793,7 +791,7 @@ int TryRunTics (void)
 
         if (!PlayersInGame())
         {
-            return ticsRan;
+            return;
         }
 
         set = &ticdata[(gametic / ticdup) % BACKUPTICS];
@@ -812,7 +810,6 @@ int TryRunTics (void)
 
             loop_interface->RunTic(set->cmds, set->ingame);
 	    gametic++;
-	    ticsRan++;
 
 	    // modify command for duplicated tics
 
@@ -821,7 +818,6 @@ int TryRunTics (void)
 
 	NetUpdate ();	// check for new console commands
     }
-    return ticsRan;
 }
 
 void D_RegisterLoopCallbacks(loop_interface_t *i)

--- a/doomgeneric/d_loop.h
+++ b/doomgeneric/d_loop.h
@@ -59,7 +59,7 @@ void NetUpdate (void);
 void D_QuitNetGame (void);
 
 //? how many ticks to run?
-int TryRunTics (void);
+void TryRunTics (void);
 
 // Called at start of game loop to initialize timers
 void D_StartGameLoop(void);

--- a/doomgeneric/d_main.c
+++ b/doomgeneric/d_main.c
@@ -404,21 +404,15 @@ boolean D_GrabMouseCallback(void)
 
 void doomgeneric_Tick()
 {
-    int ret;
     // frame syncronous IO operations
     I_StartFrame ();
 
-    ret = TryRunTics (); // may run 0 tics if we're ahead of schedule
-			 // (and we are, on anything modern)
+    TryRunTics (); // will run at least one tic
 
     S_UpdateSounds (players[consoleplayer].mo);// move positional sounds
 
     // Update display, next frame, with current state.
-    //
-    // Don't bother displaying if we haven't ran any tics,
-    // since we'd just be painting the exact same image from
-    // last tic (waste of processing power)
-    if (screenvisible && ret > 0)
+    if (screenvisible)
     {
         D_Display ();
     }


### PR DESCRIPTION
Reverts ozkl/doomgeneric#26

This caused input system to behave wrong, so I am reverting. In my system, when I release a key, its effect continues for some time. Possibly queue consuming problem.