### PR TITLE
Refactor boolean type definition for C++/-std=gnu23 compatibility

### DIFF
--- a/doomgeneric/doomtype.h
+++ b/doomgeneric/doomtype.h
@@ -33,7 +33,7 @@
 #else
 
 #include <strings.h>
-
+#include <stdbool.h>
 #endif
 
 
@@ -62,18 +62,18 @@
 
 #include <inttypes.h>
 
-#ifdef __cplusplus
+#ifdef __cplusplus || defined(__bool_true_false_are_defined)
 
 // Use builtin bool type with C++.
 
-typedef bool boolean;
+typedef int boolean;
 
 #else
 
 typedef enum 
 {
-    false	= 0,
-    true	= 1,
+    //false	= 0,
+    //true	= 1,
 	undef	= 0xFFFFFFFF
 } boolean;
 


### PR DESCRIPTION
Changed the definition of 'boolean' type for C++ & -std=gnu23 compatibility, and included base <stdbool.h> header.

This is to help bring it more inline with other source ports (Chocolate Doom mainly) and keep compatibility with new toolchains I think. I didn't come up with this fix (https://blog.svgames.pl/article/the-little-bool-of-doom) but it's helped me work on a port of doomgeneric to PlayStation 2

How easy would it be to get audio working? I think only SDL 1.2 works well on that platform so I'll be using GSKit instead